### PR TITLE
fixed typo in japanese short-title

### DIFF
--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1,5 +1,5 @@
 {
-    "short-title": "リス",
+    "short-title": "ピーナッツ",
     "long-title": "アユンダ・リスのピーナッツ! (⊙＿⊙) リスのピーナッツはどこ~?",
     "about-title": "アユンダ・リスのサイト",
     "about-subtitle": "<a target='_blank' href='https://github.com/iDevoid/risu-peanuts'>https://github.com/iDevoid/risu-peanuts</a>",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1,5 +1,5 @@
 {
-    "short-title": "ムーんあ",
+    "short-title": "リス",
     "long-title": "アユンダ・リスのピーナッツ! (⊙＿⊙) リスのピーナッツはどこ~?",
     "about-title": "アユンダ・リスのサイト",
     "about-subtitle": "<a target='_blank' href='https://github.com/iDevoid/risu-peanuts'>https://github.com/iDevoid/risu-peanuts</a>",


### PR DESCRIPTION
When I browsed the site from my smartphone, I discovered a mistake.
🐿's Japanese short-title is wrong.

I found similar mistakes in other repositories.